### PR TITLE
Fix customer service behavioral gaps vs Magento PHP source

### DIFF
--- a/internal/errors/messages.go
+++ b/internal/errors/messages.go
@@ -31,4 +31,25 @@ var (
 )
 
 // Address errors
-var ErrAddressNotOwned = fmt.Errorf("address doesn't belong to this customer")
+var (
+	ErrAddressNotOwned              = fmt.Errorf("address doesn't belong to this customer")
+	ErrAddressDefaultBillingDelete  = func(id int) error {
+		return fmt.Errorf("Customer Address %d is set as default billing address and can not be deleted", id)
+	}
+	ErrAddressDefaultShippingDelete = func(id int) error {
+		return fmt.Errorf("Customer Address %d is set as default shipping address and can not be deleted", id)
+	}
+)
+
+// Account confirmation errors
+var ErrEmailConfirmationRequired = fmt.Errorf("This account isn't confirmed. Verify and try again.")
+
+// Account lock errors
+var ErrAccountLocked = fmt.Errorf("The account is locked.")
+
+// Email format errors (exact Magento messages differ per operation)
+var (
+	ErrEmailInvalidFormat   = fmt.Errorf("The email address has an invalid format.")
+	ErrEmailInvalid         = fmt.Errorf("Email is invalid")
+	ErrEmailAddressNotValid = fmt.Errorf("Email address is not valid")
+)

--- a/internal/errors/messages.go
+++ b/internal/errors/messages.go
@@ -5,10 +5,7 @@ package errors
 import "fmt"
 
 // Auth errors
-var (
-	ErrUnauthorized = fmt.Errorf("The current customer isn't authorized.")
-	ErrAuthFailed   = fmt.Errorf("The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later.")
-)
+var ErrAuthFailed = fmt.Errorf("The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later.")
 
 // Password errors
 var (

--- a/internal/service/customer.go
+++ b/internal/service/customer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	custerr "github.com/magendooro/magento2-customer-graphql-go/internal/errors"
+	"github.com/magendooro/magento2-go-common/mgerrors"
 
 	"github.com/magendooro/magento2-customer-graphql-go/graph/model"
 	"github.com/magendooro/magento2-go-common/middleware"
@@ -63,7 +64,7 @@ func NewCustomerService(
 func (s *CustomerService) GetCustomer(ctx context.Context) (*model.Customer, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return nil, custerr.ErrUnauthorized
+		return nil, mgerrors.ErrUnauthorized
 	}
 
 	data, err := s.customerRepo.GetByID(ctx, customerID)
@@ -149,7 +150,7 @@ func (s *CustomerService) GenerateToken(ctx context.Context, email, password str
 func (s *CustomerService) RevokeToken(ctx context.Context) (*model.RevokeCustomerTokenOutput, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return nil, custerr.ErrUnauthorized
+		return nil, mgerrors.ErrUnauthorized
 	}
 
 	err := s.tokenRepo.RevokeAllForCustomer(ctx, customerID)
@@ -248,7 +249,7 @@ func (s *CustomerService) CreateCustomer(ctx context.Context, input model.Custom
 func (s *CustomerService) UpdateCustomer(ctx context.Context, input model.CustomerUpdateInput) (*model.CustomerOutput, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return nil, custerr.ErrUnauthorized
+		return nil, mgerrors.ErrUnauthorized
 	}
 
 	fields := make(map[string]interface{})
@@ -305,7 +306,7 @@ func (s *CustomerService) UpdateCustomer(ctx context.Context, input model.Custom
 func (s *CustomerService) ChangePassword(ctx context.Context, currentPassword, newPassword string) (*model.Customer, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return nil, custerr.ErrUnauthorized
+		return nil, mgerrors.ErrUnauthorized
 	}
 
 	data, err := s.customerRepo.GetByID(ctx, customerID)
@@ -346,7 +347,7 @@ func (s *CustomerService) ChangePassword(ctx context.Context, currentPassword, n
 func (s *CustomerService) UpdateEmail(ctx context.Context, email, password string) (*model.CustomerOutput, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return nil, custerr.ErrUnauthorized
+		return nil, mgerrors.ErrUnauthorized
 	}
 
 	data, err := s.customerRepo.GetByID(ctx, customerID)
@@ -387,7 +388,7 @@ func (s *CustomerService) UpdateEmail(ctx context.Context, email, password strin
 func (s *CustomerService) CreateAddress(ctx context.Context, input model.CustomerAddressInput) (*model.CustomerAddress, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return nil, custerr.ErrUnauthorized
+		return nil, mgerrors.ErrUnauthorized
 	}
 
 	data := s.mapAddressInput(input)
@@ -419,7 +420,7 @@ func (s *CustomerService) CreateAddress(ctx context.Context, input model.Custome
 func (s *CustomerService) UpdateAddress(ctx context.Context, addressID int, input model.CustomerAddressInput) (*model.CustomerAddress, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return nil, custerr.ErrUnauthorized
+		return nil, mgerrors.ErrUnauthorized
 	}
 
 	// Verify ownership
@@ -457,7 +458,7 @@ func (s *CustomerService) UpdateAddress(ctx context.Context, addressID int, inpu
 func (s *CustomerService) DeleteAddress(ctx context.Context, addressID int) (bool, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return false, custerr.ErrUnauthorized
+		return false, mgerrors.ErrUnauthorized
 	}
 
 	existing, err := s.addressRepo.GetByID(ctx, addressID)
@@ -487,7 +488,7 @@ func (s *CustomerService) DeleteAddress(ctx context.Context, addressID int) (boo
 func (s *CustomerService) DeleteCustomer(ctx context.Context) (bool, error) {
 	customerID := middleware.GetCustomerID(ctx)
 	if customerID == 0 {
-		return false, custerr.ErrUnauthorized
+		return false, mgerrors.ErrUnauthorized
 	}
 
 	s.tokenRepo.RevokeAllForCustomer(ctx, customerID)

--- a/internal/service/customer.go
+++ b/internal/service/customer.go
@@ -130,6 +130,11 @@ func (s *CustomerService) GenerateToken(ctx context.Context, email, password str
 		return nil, err
 	}
 
+	// Check email confirmation — if confirmation key is set, account is unconfirmed
+	if data.Confirmation != nil && *data.Confirmation != "" {
+		return nil, custerr.ErrEmailConfirmationRequired
+	}
+
 	if !repository.VerifyPassword(data.PasswordHash, password) {
 		s.recordLoginFailure(ctx, data.EntityID)
 		return nil, authErr
@@ -166,6 +171,10 @@ func (s *CustomerService) RevokeToken(ctx context.Context) (*model.RevokeCustome
 // Respects Magento's guest_checkout/login config — when disabled (default in 2.4.6+),
 // always returns true to prevent email enumeration.
 func (s *CustomerService) IsEmailAvailable(ctx context.Context, email string) (*model.IsEmailAvailableOutput, error) {
+	if !isValidEmail(email) {
+		return nil, custerr.ErrEmailInvalid
+	}
+
 	// Check if email availability check is enabled (Magento default: disabled)
 	storeID := middleware.GetStoreID(ctx)
 	if !s.cp.GetBool("customer/account/login/email_availability_check", storeID) {
@@ -229,10 +238,13 @@ func (s *CustomerService) CreateCustomer(ctx context.Context, input model.Custom
 		return nil, err
 	}
 
-	// Handle newsletter subscription
+	// Handle newsletter subscription (only if newsletter module is active)
 	if input.IsSubscribed != nil && *input.IsSubscribed {
-		if err := s.newsletterRepo.Subscribe(ctx, id, storeID, input.Email); err != nil {
-			log.Warn().Err(err).Int("customer_id", id).Msg("newsletter subscribe failed")
+		newsletterActive := s.cp.GetInt("newsletter/general/active", storeID, 1)
+		if newsletterActive == 1 {
+			if err := s.newsletterRepo.Subscribe(ctx, id, storeID, input.Email); err != nil {
+				log.Warn().Err(err).Int("customer_id", id).Msg("newsletter subscribe failed")
+			}
 		}
 	}
 
@@ -469,13 +481,15 @@ func (s *CustomerService) DeleteAddress(ctx context.Context, addressID int) (boo
 		return false, custerr.ErrAddressNotOwned
 	}
 
-	// Clear default references if needed
+	// Block deletion of default billing or shipping addresses (Magento behavior)
 	customer, _ := s.customerRepo.GetByID(ctx, customerID)
-	if customer.DefaultBilling != nil && *customer.DefaultBilling == addressID {
-		s.customerRepo.Update(ctx, customerID, map[string]interface{}{"default_billing": nil})
-	}
-	if customer.DefaultShipping != nil && *customer.DefaultShipping == addressID {
-		s.customerRepo.Update(ctx, customerID, map[string]interface{}{"default_shipping": nil})
+	if customer != nil {
+		if customer.DefaultBilling != nil && *customer.DefaultBilling == addressID {
+			return false, custerr.ErrAddressDefaultBillingDelete(addressID)
+		}
+		if customer.DefaultShipping != nil && *customer.DefaultShipping == addressID {
+			return false, custerr.ErrAddressDefaultShippingDelete(addressID)
+		}
 	}
 
 	if err := s.addressRepo.Delete(ctx, addressID); err != nil {
@@ -502,6 +516,10 @@ func (s *CustomerService) DeleteCustomer(ctx context.Context) (bool, error) {
 // RequestPasswordResetEmail generates a reset token and stores it.
 // Returns true regardless of whether the email exists (prevents enumeration).
 func (s *CustomerService) RequestPasswordResetEmail(ctx context.Context, email string) (bool, error) {
+	if !isValidEmail(email) {
+		return false, custerr.ErrEmailInvalidFormat
+	}
+
 	storeID := middleware.GetStoreID(ctx)
 	websiteID, _ := s.storeRepo.GetWebsiteIDForStore(ctx, storeID)
 
@@ -509,6 +527,10 @@ func (s *CustomerService) RequestPasswordResetEmail(ctx context.Context, email s
 	if err != nil {
 		// Don't reveal whether the email exists
 		return true, nil
+	}
+
+	if isCustomerLocked(data) {
+		return false, custerr.ErrAccountLocked
 	}
 
 	// Generate a random reset token
@@ -530,6 +552,10 @@ func (s *CustomerService) RequestPasswordResetEmail(ctx context.Context, email s
 
 // ResetPassword validates the reset token and updates the password.
 func (s *CustomerService) ResetPassword(ctx context.Context, email, resetPasswordToken, newPassword string) (bool, error) {
+	if !isValidEmail(email) {
+		return false, custerr.ErrEmailInvalidFormat
+	}
+
 	storeID := middleware.GetStoreID(ctx)
 	websiteID, _ := s.storeRepo.GetWebsiteIDForStore(ctx, storeID)
 
@@ -538,14 +564,20 @@ func (s *CustomerService) ResetPassword(ctx context.Context, email, resetPasswor
 		return false, custerr.ErrNoSuchEmail(email)
 	}
 
+	if isCustomerLocked(data) {
+		return false, custerr.ErrAccountLocked
+	}
+
 	if data.RPToken == nil || *data.RPToken != resetPasswordToken {
 		return false, custerr.ErrPasswordTokenBad
 	}
 
-	// Check token expiry (default: 2 hours)
+	// Check token expiry using config (customer/password/reset_link_expiration_period, in days, default: 1)
 	if data.RPTokenCreatedAt != nil {
+		expiryDays := s.cp.GetInt("customer/password/reset_link_expiration_period", storeID, 1)
+		expiryDuration := time.Duration(expiryDays) * 24 * time.Hour
 		created, err := time.Parse("2006-01-02 15:04:05", *data.RPTokenCreatedAt)
-		if err == nil && time.Since(created) > 2*time.Hour {
+		if err == nil && time.Since(created) > expiryDuration {
 			return false, custerr.ErrPasswordResetExpiry
 		}
 	}
@@ -574,6 +606,10 @@ func (s *CustomerService) ResetPassword(ctx context.Context, email, resetPasswor
 
 // ConfirmEmail confirms a customer's email using a confirmation key.
 func (s *CustomerService) ConfirmEmail(ctx context.Context, input model.ConfirmEmailInput) (*model.CustomerOutput, error) {
+	if !isValidEmail(input.Email) {
+		return nil, custerr.ErrEmailInvalid
+	}
+
 	storeID := middleware.GetStoreID(ctx)
 	websiteID, _ := s.storeRepo.GetWebsiteIDForStore(ctx, storeID)
 
@@ -597,8 +633,21 @@ func (s *CustomerService) ConfirmEmail(ctx context.Context, input model.ConfirmE
 	return &model.CustomerOutput{Customer: s.mapCustomer(updated)}, nil
 }
 
-// ResendConfirmationEmail is a no-op (email sending not implemented).
+// ResendConfirmationEmail validates the email and logs the request (email sending not implemented).
 func (s *CustomerService) ResendConfirmationEmail(ctx context.Context, email string) (bool, error) {
+	if !isValidEmail(email) {
+		return false, custerr.ErrEmailAddressNotValid
+	}
+
+	storeID := middleware.GetStoreID(ctx)
+	websiteID, _ := s.storeRepo.GetWebsiteIDForStore(ctx, storeID)
+
+	_, err := s.customerRepo.GetByEmail(ctx, email, websiteID)
+	if err != nil {
+		// Don't reveal whether the email exists
+		return true, nil
+	}
+
 	log.Info().Str("email", email).Msg("resend confirmation email requested (email sending not implemented)")
 	return true, nil
 }

--- a/internal/service/security.go
+++ b/internal/service/security.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	custerr "github.com/magendooro/magento2-customer-graphql-go/internal/errors"
@@ -36,4 +37,28 @@ func (s *CustomerService) recordLoginFailure(ctx context.Context, customerID int
 // resetLoginFailures clears the failure counter on successful login.
 func (s *CustomerService) resetLoginFailures(ctx context.Context, customerID int) {
 	s.customerRepo.ResetLoginFailures(ctx, customerID)
+}
+
+// isValidEmail performs basic email format validation matching filter_var(FILTER_VALIDATE_EMAIL).
+func isValidEmail(email string) bool {
+	at := strings.Index(email, "@")
+	if at < 1 {
+		return false
+	}
+	local := email[:at]
+	domain := email[at+1:]
+	if len(local) == 0 || len(domain) < 3 {
+		return false
+	}
+	dot := strings.LastIndex(domain, ".")
+	return dot > 0 && dot < len(domain)-1
+}
+
+// isCustomerLocked returns true if the customer account is currently locked.
+func isCustomerLocked(data *repository.CustomerData) bool {
+	if data.LockExpires == nil || *data.LockExpires == "" {
+		return false
+	}
+	lockExpires, err := time.Parse("2006-01-02 15:04:05", *data.LockExpires)
+	return err == nil && time.Now().UTC().Before(lockExpires)
 }


### PR DESCRIPTION
## Summary

- **generateCustomerToken**: Block login if `customer_entity.confirmation` is set — Magento throws `EmailNotConfirmedException` ("This account isn't confirmed. Verify and try again.")
- **deleteAddress**: Block deletion of default billing/shipping addresses with exact Magento error messages ("Customer Address %d is set as default billing address and can not be deleted") — previously silently cleared the default reference and deleted
- **requestPasswordResetEmail**: Validate email format (throws "The email address has an invalid format."), check account lockout ("The account is locked.") before setting reset token
- **resetPassword**: Validate email format, check account lockout, fix token expiry from hardcoded 2h to config `customer/password/reset_link_expiration_period` (days, default: 1 day)
- **isEmailAvailable**: Validate email format before availability check ("Email is invalid")
- **confirmEmail**: Validate email format before key lookup ("Email is invalid")
- **resendConfirmationEmail**: Validate email format ("Email address is not valid"), check customer exists (was pure no-op); still logs since email sending is not implemented
- **createCustomer**: Respect `newsletter/general/active` config — don't subscribe if newsletter module is disabled

## Test plan

- [x] `GOTOOLCHAIN=auto go build ./...` — clean
- [x] `GOTOOLCHAIN=auto go vet ./...` — clean
- [x] All 72 tests pass (`go test ./... -count=1 -timeout 120s`)
- [x] All comparison tests pass (`go test ./tests/ -run "^TestCompare" -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)